### PR TITLE
Tweak install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This is a [Textmate][textmate] bundle containing a port of the [Atom Dark][atom-
 
 ### Installation
 
-Installation is as simple as cloning the repository either into `~/Library/Application Support/Avian/Bundles` or
-cloning it elsewhere and symlinking it within the aforementioned location.
+Installation is as simple as:
+1) Clone the repository
+2) Copy or symlink the .tmtheme file into `~/Library/Application Support/Avian/Bundles/Themes`
 
 [atom-dark-syntax]: https://github.com/atom/atom-dark-syntax
 [atom-io]: https://atom.io/


### PR DESCRIPTION
- The embedded "Themes" folder caused issues with install - reworked install instructions to address.
